### PR TITLE
bugfix/2016.11.30_fixup-new-return-patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   1. Add ex_redis_pool to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:ex_redis_pool, "~> 0.1.0"}]
+          [{:ex_redis_pool, "~> 0.1.1"}]
         end
 
   2. Ensure ex_redis_pool is started before your application:
@@ -117,8 +117,8 @@ queries are mapped to the appropriate shard based on the given `shard_key` like 
 ```elixir
 iex(1)> shard_opts_list = [[database: 10], [database: 11], [database: 12], [database: 13]]
 [[database: 10], [database: 11], [database: 12], [database: 13]]
-iex(2)> {:ok, pid} = ExRedisPool.Shard.new(shard_opts_list)
-{:ok, #PID<0.575.0>}
+iex(2)> pid = ExRedisPool.Shard.new(shard_opts_list)
+#PID<0.575.0>
 iex(3)> ExRedisPool.Shard.q(pid, ["SET", "chuck", "norris"], "texas")
 {:ok, "OK"}
 iex(4)> ExRedisPool.Shard.q(pid, ["GET", "chuck"], "texas")

--- a/lib/ex_redis_pool.ex
+++ b/lib/ex_redis_pool.ex
@@ -43,7 +43,7 @@ defmodule ExRedisPool do
   @doc """
   Start a new redis connection pool within ExRedisPools own supervision tree..
   """
-  @spec new(pool, [redis_pool_option]) :: {:ok, pool} | {:error, reason}
+  @spec new(pool, [redis_pool_option]) :: pid
   def new(pool, opts) when is_atom(pool) and is_list(opts) do
     worker_opts = [
       id: :erlang.make_ref()
@@ -53,7 +53,7 @@ defmodule ExRedisPool do
     pid
   end
 
-  @spec new([redis_pool_option]) :: {:ok, pool} | {:error, reason}
+  @spec new([redis_pool_option]) :: pid
   def new(opts) when is_list(opts) do
     worker_opts = [
       id: :erlang.make_ref()
@@ -63,12 +63,12 @@ defmodule ExRedisPool do
     pid
   end
 
-  @spec new(pool) :: {:ok, pool} | {:error, reason}
+  @spec new(pool) :: pid
   def new(pool) when is_atom(pool) do
     new(pool, [])
   end
 
-  @spec new() :: {:ok, pool} | {:error, reason}
+  @spec new() :: pid
   def new() do
     new([])
   end

--- a/lib/ex_redis_pool/shard.ex
+++ b/lib/ex_redis_pool/shard.ex
@@ -52,23 +52,25 @@ defmodule ExRedisPool.Shard do
   Takes a list of connection options for each shard. Each shard is assigned an
   index based on the order of the connection options.
   """
-  @spec new([redis_pool_options]) :: {:ok, pool} | {:error, reason}
+  @spec new([redis_pool_options]) :: pid
   def new(shard_opts_list) do
     shards = start_shards(shard_opts_list)
     worker_opts = [id: :erlang.make_ref()]
     {:ok, child} =
       Supervisor.start_child(__MODULE__, worker(ExRedisPool.ShardMapper, [shards], worker_opts))
+    child
   end
 
   @doc """
   Like `new/1` but with the option to give an atom name.
   """
-  @spec new(mapper, [redis_pool_options]) :: {:ok, pool} | {:error, reason}
+  @spec new(mapper, [redis_pool_options]) :: pid
   def new(mapper, shard_opts_list) do
     shards = start_shards(shard_opts_list)
     worker_opts = [id: :erlang.make_ref()]
     {:ok, child} =
       Supervisor.start_child(__MODULE__, worker(ExRedisPool.ShardMapper, [mapper, shards], worker_opts))
+    child
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExRedisPool.Mixfile do
 
   def project do
     [app: :ex_redis_pool,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/ex_redis_pool/shard_mapper_test.exs
+++ b/test/ex_redis_pool/shard_mapper_test.exs
@@ -10,7 +10,8 @@ defmodule ExRedisPool.ShardMapperTest do
       [database: 13],
     ]
 
-    {:ok, pid} = ExRedisPool.Shard.new(shard_opts_list)
+    pid = ExRedisPool.Shard.new(shard_opts_list)
+    assert is_pid(pid)
 
     # run a few iterations to make sure we distribute across the shards
     for _ <- 0..100 do
@@ -37,7 +38,8 @@ defmodule ExRedisPool.ShardMapperTest do
       [database: 13],
     ]
 
-    {:ok, pid} = ExRedisPool.Shard.new(shard_opts_list)
+    pid = ExRedisPool.Shard.new(shard_opts_list)
+    assert is_pid(pid)
 
     # run a few iterations to make sure we distribute across the shards
     for _ <- 0..100 do
@@ -60,7 +62,8 @@ defmodule ExRedisPool.ShardMapperTest do
       [database: 15],
     ]
 
-    {:ok, pid} = ExRedisPool.Shard.new(:test_shard_map, shard_opts_list)
+    pid = ExRedisPool.Shard.new(:test_shard_map, shard_opts_list)
+    assert is_pid(pid)
 
     # run a few iterations to make sure we distribute across the shards
     for _ <- 0..10 do


### PR DESCRIPTION
Fixes:
- typespecs for `ExRedisPool.new`
- typespecs for `ExRedisPool.Shard.new`
- return type for `ExRedisPool.Shard.new` 
- update version to `0.1.1`
